### PR TITLE
Add empty permissions list to expo app.json

### DIFF
--- a/packages/harpguru-expo-boilerplate/app.json
+++ b/packages/harpguru-expo-boilerplate/app.json
@@ -23,7 +23,8 @@
     },
     "android": {
       "package": "com.jslog.harpguru",
-      "versionCode": 5
+      "versionCode": 5,
+      "permissions": []
     }
   }
 }


### PR DESCRIPTION
This is responsible for building the manifest I believe. I have no idea
whether this is sufficient, but we'll have to see.