### PR TITLE
Increment android version to 6

### DIFF
--- a/packages/harpguru-expo-boilerplate/CHANGELOG.md
+++ b/packages/harpguru-expo-boilerplate/CHANGELOG.md
@@ -100,7 +100,7 @@ AT THIS POINT THE TAGS ARE NOW MADE IN THE `harpguru` PROJECT AND MAY NO LONGER 
 
 ## Github release list
 
-- [unreleased](https://github.com/js-jslog/harpguru/compare/v3.0.0...HEAD)
+- [unreleased](https://github.com/js-jslog/harpguru/compare/v3.1.0...HEAD)
 - [v2.1.0](https://github.com/js-jslog/harpguru/releases/tag/v3.1.0)
 - [v2.0.0](https://github.com/js-jslog/harpguru/releases/tag/v3.0.0)
 - [v1.4.0](https://github.com/js-jslog/harpguru/releases/tag/v2.0.0)

--- a/packages/harpguru-expo-boilerplate/CHANGELOG.md
+++ b/packages/harpguru-expo-boilerplate/CHANGELOG.md
@@ -13,7 +13,13 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 - Fixed: for any bug fixes.
 - Security: to invite users to upgrade in case of vulnerabilities.
 
-## [Unreleased](https://github.com/js-jslog/harpguru/compare/v3.0.0...master) - yyyy-mm-dd
+## [Unreleased](https://github.com/js-jslog/harpguru/compare/v3.1.0...master) - yyyy-mm-dd
+
+## [v2.1.0](https://github.com/js-jslog/harpguru/releases/tag/v3.1.0) - 2020-10-10
+
+### Changed
+
+- MINOR: Increment android version number to 6 since 5 was already in use in the android console by my discarded release
 
 ## [v2.0.0](https://github.com/js-jslog/harpguru/releases/tag/v3.0.0) - 2020-10-10
 
@@ -95,6 +101,7 @@ AT THIS POINT THE TAGS ARE NOW MADE IN THE `harpguru` PROJECT AND MAY NO LONGER 
 ## Github release list
 
 - [unreleased](https://github.com/js-jslog/harpguru/compare/v3.0.0...HEAD)
+- [v2.1.0](https://github.com/js-jslog/harpguru/releases/tag/v3.1.0)
 - [v2.0.0](https://github.com/js-jslog/harpguru/releases/tag/v3.0.0)
 - [v1.4.0](https://github.com/js-jslog/harpguru/releases/tag/v2.0.0)
 - [v1.3.0](https://github.com/js-jslog/harpguru/releases/tag/v1.3.0)

--- a/packages/harpguru-expo-boilerplate/app.json
+++ b/packages/harpguru-expo-boilerplate/app.json
@@ -3,7 +3,7 @@
     "name": "Harp Guru",
     "slug": "harp-guru",
     "platforms": ["ios", "android", "web"],
-    "version": "3.0.0",
+    "version": "3.1.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {
@@ -23,7 +23,7 @@
     },
     "android": {
       "package": "com.jslog.harpguru",
-      "versionCode": 5,
+      "versionCode": 6,
       "permissions": []
     }
   }

--- a/packages/harpguru-expo-boilerplate/package.json
+++ b/packages/harpguru-expo-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harpguru-expo-boilerplate",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "An expo based boilerplate to run the harpguru-core app",
   "main": "__generated__/AppEntry.js",
   "scripts": {


### PR DESCRIPTION
Apparently this is required even though the previous version 5 (v2.0.0)
was discarded. Seems like google keep it on record.