### PR TITLE
Place all hooks calls above conditional return statements

### DIFF
--- a/packages/harpguru-core/src/components/harp-cell/harp-cell.tsx
+++ b/packages/harpguru-core/src/components/harp-cell/harp-cell.tsx
@@ -31,11 +31,14 @@ export const HarpCell = ({ yxCoord }: HarpCellProps): React.ReactElement => {
     yxCoord
   )
   const baseHarpCellStyles = getBaseHarpCellStyles()
+  const setPozitionRoot = useSetPozitionRoot()
+  const toggleHarpCell = useToggleHarpCell()
+  const [activeDisplayMode] = useGlobal('activeDisplayMode')
+  const [activeExperienceMode] = useGlobal('activeExperienceMode')
 
   if (thisDegreeId === undefined || thisPitchId === undefined)
     return <MemoHarpCellInaccessible baseStyles={baseHarpCellStyles} />
 
-  const setPozitionRoot = useSetPozitionRoot()
   const handleLongPressStateChange = ({
     nativeEvent,
   }: TapGestureHandlerStateChangeEvent) => {
@@ -44,7 +47,6 @@ export const HarpCell = ({ yxCoord }: HarpCellProps): React.ReactElement => {
     setPozitionRoot(thisPitchId)
   }
 
-  const toggleHarpCell = useToggleHarpCell()
   const handleTapStateChange = ({
     nativeEvent,
   }: TapGestureHandlerStateChangeEvent) => {
@@ -53,8 +55,6 @@ export const HarpCell = ({ yxCoord }: HarpCellProps): React.ReactElement => {
     toggleHarpCell(thisDegreeId)
   }
 
-  const [activeDisplayMode] = useGlobal('activeDisplayMode')
-  const [activeExperienceMode] = useGlobal('activeExperienceMode')
   const harpCellAccessibleProps = {
     degreeId: thisDegreeId,
     pitchId: thisPitchId,


### PR DESCRIPTION
#30 introduced a bug producing the following error when a new apparatus is selected:

```
Warning: React has detected a change in the order of Hooks called by %s. This will lead to bugs and errors if not fixed. For more information, read the Rules of Hooks: https://fb.me/rules-of-hooks
```