### PR TITLE
Export harpguru core type definitions to avoid errors in dependants

### DIFF
--- a/packages/harpguru-core/CHANGELOG.md
+++ b/packages/harpguru-core/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [Unreleased](https://github.com/js-jslog/harpguru/compare/v4.0.0...HEAD) - yyyy-mm-dd
 
+### Added
+
+- MINOR: Include type definition exports so that consumers benefit from polyfills and reactn global state definition
+
 ### Changed
 
 - MINOR: Improved presentatability of option enums

--- a/packages/harpguru-core/package.json
+++ b/packages/harpguru-core/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "A React Native implementation of the HarpGuru concept; a UI to aid the understanding of harmonica music theory",
   "main": "./src/index.ts",
+  "types": "./src/index.d.ts",
   "author": "js-jslog <josephsinfield@yahoo.com>",
   "license": "UNLICENSED",
   "scripts": {

--- a/packages/harpguru-core/src/components/harp-cell/hooks/use-tap-rerender-logic/use-tap-rerender-logic.ts
+++ b/packages/harpguru-core/src/components/harp-cell/hooks/use-tap-rerender-logic/use-tap-rerender-logic.ts
@@ -19,8 +19,12 @@ export const useTapRerenderLogic = (
   const [bufferedActivityToggles] = useGlobal('bufferedActivityToggles')
   const isGloballyActive = thisIsActiveId === IsActiveIds.Active
   const isLocallyActive =
-    (!isGloballyActive && bufferedActivityToggles.includes(thisDegreeId)) ||
-    (isGloballyActive && !bufferedActivityToggles.includes(thisDegreeId))
+    (thisDegreeId !== undefined &&
+      !isGloballyActive &&
+      bufferedActivityToggles.includes(thisDegreeId)) ||
+    (thisDegreeId !== undefined &&
+      isGloballyActive &&
+      !bufferedActivityToggles.includes(thisDegreeId))
 
   const initialCellState = isGloballyActive ? CellStates.On : CellStates.Off
   const [cellState, setCellState] = React.useState(initialCellState)

--- a/packages/harpguru-core/src/global.d.ts
+++ b/packages/harpguru-core/src/global.d.ts
@@ -1,17 +1,9 @@
 import 'reactn'
-import type { HarpStrata } from 'harpstrata'
+import type { HarpStrata, DegreeIds } from 'harpstrata'
 
 import type { CovariantMembers } from './packages/covariance-series'
 
 import type { DisplayModes, ExperienceModes } from './types'
-
-// All of the `dispatch: any` lines in here are
-// required because of a typescript complaint
-// about circular references on the `useDispatch`
-// calls which reference these reducers. I believe
-// I have followed the rules perfectly here but I
-// cannot figure out why this error occurs and this
-// is the best workaround I can figure out for now.
 
 declare module 'reactn/default' {
   export interface State {

--- a/packages/harpguru-core/src/index.d.ts
+++ b/packages/harpguru-core/src/index.d.ts
@@ -1,0 +1,6 @@
+import './global'
+import '../typings/polyfills.d'
+
+import type { ReactElement } from 'react'
+
+export const HarpGuru: () => ReactElement

--- a/packages/harpguru-core/src/index.ts
+++ b/packages/harpguru-core/src/index.ts
@@ -1,1 +1,11 @@
+// Import type definitions to index.ts so that
+// dependants benefit from them too.
+// These imports aren't required for this project
+// since `global` and `typings` are referenced
+// automatically in a local context. When this
+// project is imported, these types are otherwise
+// ignored which is a problem.
+import './global'
+import '../typings/polyfills.d'
+
 export { HarpGuru } from './components'

--- a/packages/harpguru-core/src/index.ts
+++ b/packages/harpguru-core/src/index.ts
@@ -1,11 +1,1 @@
-// Import type definitions to index.ts so that
-// dependants benefit from them too.
-// These imports aren't required for this project
-// since `global` and `typings` are referenced
-// automatically in a local context. When this
-// project is imported, these types are otherwise
-// ignored which is a problem.
-import './global'
-import '../typings/polyfills.d'
-
 export { HarpGuru } from './components'

--- a/packages/harpstrata/CHANGELOG.md
+++ b/packages/harpstrata/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 - MINOR: Improved presentatability of option enums
 - MINOR: Remove devDependencies (hoisted to workspace development context)
 
+### Fixed
+
+- MINOR: Add necessary import for reactn global state and fix consequentially highlighted but practically impotent linting error
+
 ## [v7.3.0](https://github.com/js-jslog/harpguru/releases/tag/v1.3.0) - 2020-09-13
 
 ### Added


### PR DESCRIPTION
Following a correction in the package json of the expo boilerplate project in #2 the typescript checking began to fail due to an absence of the reactn and polyfill types which the harpguru-core project requires to be valid. All that needed to change was that those type definitions which were already included within the harpguru-core project needed to be exported.