### PR TITLE
Only present active cells on first page

### DIFF
--- a/packages/harpguru-core/CHANGELOG.md
+++ b/packages/harpguru-core/CHANGELOG.md
@@ -20,9 +20,10 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 - MAJOR: Quick access option buttons for display and experience mode
 - MINOR: Ability choose whether the harpface is fragmented at the octaves or not
 
-### Chaned
+### Changed
 
 - MINOR: Flush toggles differently in Quiz mode to Explore mode to improve experience
+- MINOR: Only setup the first page with buffered toggles to flush on app initialisation
 
 ### Removed
 

--- a/packages/harpguru-core/src/components/harp-guru/utils/get-initial-global-state/get-initial-global-state.ts
+++ b/packages/harpguru-core/src/components/harp-guru/utils/get-initial-global-state/get-initial-global-state.ts
@@ -27,25 +27,6 @@ export const getInitialGlobalState = (pageNumber: PageNumber): GlobalState => {
   }
   const { [pageNumber]: pozitionId } = pozitionMap
 
-  // The idea of what happens next is that since the 12 bar blues will be
-  // the most common use case, I want the 3 pages to represent the I, IV & V
-  // chords in 2nd, 1st & 3rd positions respectively, with the notes of the
-  // major pentatonic of the I chord highlighted in all of them.
-  // Basically for the benefits illustrated in https://youtu.be/ZyNb39rPpng
-  const { activePitchIds: pentatonicPitches2ndPoz } = getHarpStrata({
-    apparatusId,
-    pozitionId: PozitionIds.Second,
-    harpKeyId,
-    activeIds: getScale(ScaleIds.MajorPentatonic).degrees,
-  })
-
-  const { activeDegreeIds: thisPozitionDegrees } = getHarpStrata({
-    apparatusId,
-    pozitionId,
-    harpKeyId,
-    activeIds: pentatonicPitches2ndPoz,
-  })
-
   const initialHarpStrataProps: HarpStrataProps = {
     apparatusId,
     pozitionId,
@@ -56,6 +37,9 @@ export const getInitialGlobalState = (pageNumber: PageNumber): GlobalState => {
   const { Explore: initialExperienceMode } = ExperienceModes
   const { Degree: initialDisplayMode } = DisplayModes
   const { Pozition: initialLockedCovariant } = CovariantMembers
+
+  const thisPozitionDegrees =
+    pageNumber === 1 ? getScale(ScaleIds.MajorPentatonic).degrees : []
 
   const state = {
     activeHarpStrata: initialHarpStrata,


### PR DESCRIPTION
The purpose of this change is to reduce the number of renders at app intialisation as far as possible. Causing additional renders on pages 2 and 3 is purposeless because we won't see it. Having toggles in the buffer is guaranteed to produce an extra render when the toggles are flushed so these are the thing to remove right now.