### PR TITLE
Push menu's aside when transparent so they don't block touches to the app below in iOS

### DIFF
--- a/packages/harpguru-core/CHANGELOG.md
+++ b/packages/harpguru-core/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [Unreleased](https://github.com/js-jslog/harpguru/compare/v8.0.0...HEAD) - yyyy-mm-dd
 
+### Fixed
+
+MINOR: Ensure that menu's are swept aside so they don't invisibly block touches to the app below
+
 ## [v7.0.0](https://github.com/js-jslog/harpguru/releases/tag/v8.0.0) - 2021-01-29
 
 ### Changed

--- a/packages/harpguru-core/src/components/menu/menu.tsx
+++ b/packages/harpguru-core/src/components/menu/menu.tsx
@@ -42,10 +42,17 @@ export const Menu = ({
       style={[
         styles.animated,
         {
+          // WARNING: the order these transforms are listed is
+          // important. I think the size of the translations
+          // will be reduced proportionally to the scaling if
+          // the scaling is performed first. This is platform
+          // independent.
           transform: [
-            { translateX: slideX },
-            { translateY: slideY },
-            { scale: scale },
+            {
+              translateY: slideY,
+              translateX: slideX,
+              scale: scale,
+            },
           ],
         },
       ]}

--- a/packages/harpguru-core/src/components/notification-flash/notification-flash.tsx
+++ b/packages/harpguru-core/src/components/notification-flash/notification-flash.tsx
@@ -63,8 +63,8 @@ export const NotificationFlash = ({
           {
             transform: [
               {
-                translateX: translateX,
                 scale: multiply(messageScale, messageScaleMultiplier),
+                translateX: translateX,
               },
             ],
             opacity: messageUnderlayOpacity,

--- a/packages/harpguru-core/src/components/notification-flash/notification-flash.tsx
+++ b/packages/harpguru-core/src/components/notification-flash/notification-flash.tsx
@@ -63,6 +63,11 @@ export const NotificationFlash = ({
           {
             transform: [
               {
+                // WARNING: in iOS only; the scale *must* be performed before the
+                // translation, or the translation will not be observed at all.
+                // I do not have a good explanation for this and it doesn't seem
+                // to conform to the observation of the other comment added in
+                // this commit.
                 scale: multiply(messageScale, messageScaleMultiplier),
                 translateX: translateX,
               },


### PR DESCRIPTION
It appears that this ordering is very context dependent. There is a
similar animated transform which happens in the menu object, but that
*mustn't* be ordered the same as here.

See https://github.com/js-jslog/harpguru/pull/86#issuecomment-777689549 for a bit more of a description of the observable issue.