### PR TITLE
Remove SafeAreaView from menu lists

### DIFF
--- a/packages/harpguru-core/CHANGELOG.md
+++ b/packages/harpguru-core/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [Unreleased](https://github.com/js-jslog/harpguru/compare/v8.3.0...HEAD) - yyyy-mm-dd
 
+### Fixed
+
+MINOR: Fix positioning of option list on devices with notches
+
 ## [v7.1.0](https://github.com/js-jslog/harpguru/releases/tag/v8.3.0) - 2021-02-11
 
 ### Fixed

--- a/packages/harpguru-core/src/components/option-list/option-list.tsx
+++ b/packages/harpguru-core/src/components/option-list/option-list.tsx
@@ -1,6 +1,6 @@
 import Animated, { interpolate } from 'react-native-reanimated'
 import { FlatList } from 'react-native-gesture-handler'
-import { StyleSheet, View, SafeAreaView } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 import React from 'react'
 
 import type { OptionLabelProps } from '../option-label'
@@ -62,18 +62,16 @@ export const OptionList = ({
     >
       <View style={[common, left]}>{leftColumnLabel}</View>
       <View style={[common, right]}>{rightColumnLabel}</View>
-      <SafeAreaView style={{ ...StyleSheet.absoluteFillObject }}>
-        <FlatList
-          contentContainerStyle={{
-            alignItems: 'flex-end',
-            paddingRight: largeGutter,
-          }}
-          data={useItems()}
-          numColumns={twoColumns ? 2 : 1}
-          renderItem={({ item }) => <>{item}</>}
-          keyExtractor={(_item, index) => `${index}`}
-        />
-      </SafeAreaView>
+      <FlatList
+        contentContainerStyle={{
+          alignItems: 'flex-end',
+          paddingRight: largeGutter,
+        }}
+        data={useItems()}
+        numColumns={twoColumns ? 2 : 1}
+        renderItem={({ item }) => <>{item}</>}
+        keyExtractor={(_item, index) => `${index}`}
+      />
     </Animated.View>
   )
 }


### PR DESCRIPTION
If we're going to make use of SafeAreaView then it needs to go around
the entire app, and the sizes calculated for the entire layout need to
be based on the safe area, not the window size.

Having the SafeAreaView around the list here has meant that while the
rest of the app is in proportion and in the right location, the list is
put out of whack by it's automatic padding which isn't factored in to
the rest of the layout.