### PR TITLE
Correct the quiz question selection range

### DIFF
--- a/packages/harpguru-core/CHANGELOG.md
+++ b/packages/harpguru-core/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [Unreleased](https://github.com/js-jslog/harpguru/compare/v8.3.0...HEAD) - yyyy-mm-dd
 
+### Fixed
+
+MINOR: Add missing quiz questions
+
 ## [v7.1.0](https://github.com/js-jslog/harpguru/releases/tag/v8.3.0) - 2021-02-11
 
 ### Fixed

--- a/packages/harpguru-core/src/components/notify-of-quiz-question/utils/get-next-quiz-question/get-next-quiz-question.ts
+++ b/packages/harpguru-core/src/components/notify-of-quiz-question/utils/get-next-quiz-question/get-next-quiz-question.ts
@@ -13,7 +13,7 @@ export const getNextQuizQuestion = (
   displayMode: DisplayModes
 ): DegreeIds | PitchIds => {
   const ids = getOrderedIds(displayMode)
-  const max = ids.length - 1
+  const { length: max } = ids
   const random = Math.floor(Math.random() * max)
   const { [random]: next } = ids
 


### PR DESCRIPTION
The range needs to include the id 1 higher than the max index because
the `floor` command is used to resolve downwards.