### PR TITLE
Hide zoom menu while not ready

### DIFF
--- a/packages/harpguru-core/CHANGELOG.md
+++ b/packages/harpguru-core/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 
 ### Added
 
-- MINOR: Ability to zoom to set number of holes
 - MINOR: Pentaharp tuning added
 
 ### Changed

--- a/packages/harpguru-core/src/components/menu-of-tunings/menu-of-tunings.tsx
+++ b/packages/harpguru-core/src/components/menu-of-tunings/menu-of-tunings.tsx
@@ -11,7 +11,6 @@ import type { MenuProps } from '../../types'
 import { useSizes } from '../../hooks'
 
 import {
-  reduceZoomIdToColumnBounds,
   reduceTuningIdToHarpStrata,
   reduceValvingIdToHarpStrata,
 } from './utils'
@@ -20,8 +19,6 @@ import {
   useTuningItems,
   useValvingTitle,
   useValvingItems,
-  useZoomTitle,
-  useZoomItems,
 } from './hooks'
 
 export const MenuOfTunings = (menuProps: MenuProps): React.ReactElement => {
@@ -65,29 +62,6 @@ export const MenuOfTunings = (menuProps: MenuProps): React.ReactElement => {
     [useGlobal, valvingItemTapHandler]
   )
 
-  const useZoomTitleMemo = useCallback(() => useZoomTitle(useGlobal), [
-    useGlobal,
-  ])
-  const zoomItemTapHandler = useCallback(
-    useDispatch(
-      (currentColumnBounds, activeDegreeMatrix, zoomId) =>
-        reduceZoomIdToColumnBounds(
-          currentColumnBounds,
-          activeDegreeMatrix,
-          zoomId
-        ),
-      'sourceColumnBounds'
-    ),
-    // TODO: This and a great many other things should be based on the
-    // interaction matrix of the apparatus rather than the degreeMatrix
-    // which is much more volatile
-    [useDispatch, reduceZoomIdToColumnBounds]
-  )
-  const useZoomItemsMemo = useCallback(
-    () => useZoomItems(useGlobal, zoomItemTapHandler),
-    [useGlobal, zoomItemTapHandler]
-  )
-
   const optionStackPropsz = [
     {
       useTitle: useTuningTitleMemo,
@@ -97,11 +71,6 @@ export const MenuOfTunings = (menuProps: MenuProps): React.ReactElement => {
     {
       useTitle: useValvingTitleMemo,
       useItems: useValvingItemsMemo,
-      twoColumns: false,
-    },
-    {
-      useTitle: useZoomTitleMemo,
-      useItems: useZoomItemsMemo,
       twoColumns: false,
     },
   ]


### PR DESCRIPTION
The zoom menu is not part of a complete feature until we also have a
scrolling widget. Otherwise when users zoom they will have no way to
access the rest of the harp.

This is necessary because it is a good moment to do a release of the
pentaharp tuning and this is the only part of the current UI which is
incomplete.