### PR TITLE
Revert "Hide zoom menu while not ready"

### DIFF
--- a/packages/harpguru-core/CHANGELOG.md
+++ b/packages/harpguru-core/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 
 ### Added
 
+- MINOR: Ability to zoom to set number of holes
 - MINOR: Pentaharp tuning added
 
 ### Changed

--- a/packages/harpguru-core/src/components/menu-of-tunings/menu-of-tunings.tsx
+++ b/packages/harpguru-core/src/components/menu-of-tunings/menu-of-tunings.tsx
@@ -11,6 +11,7 @@ import type { MenuProps } from '../../types'
 import { useSizes } from '../../hooks'
 
 import {
+  reduceZoomIdToColumnBounds,
   reduceTuningIdToHarpStrata,
   reduceValvingIdToHarpStrata,
 } from './utils'
@@ -19,6 +20,8 @@ import {
   useTuningItems,
   useValvingTitle,
   useValvingItems,
+  useZoomTitle,
+  useZoomItems,
 } from './hooks'
 
 export const MenuOfTunings = (menuProps: MenuProps): React.ReactElement => {
@@ -62,6 +65,29 @@ export const MenuOfTunings = (menuProps: MenuProps): React.ReactElement => {
     [useGlobal, valvingItemTapHandler]
   )
 
+  const useZoomTitleMemo = useCallback(() => useZoomTitle(useGlobal), [
+    useGlobal,
+  ])
+  const zoomItemTapHandler = useCallback(
+    useDispatch(
+      (currentColumnBounds, activeDegreeMatrix, zoomId) =>
+        reduceZoomIdToColumnBounds(
+          currentColumnBounds,
+          activeDegreeMatrix,
+          zoomId
+        ),
+      'sourceColumnBounds'
+    ),
+    // TODO: This and a great many other things should be based on the
+    // interaction matrix of the apparatus rather than the degreeMatrix
+    // which is much more volatile
+    [useDispatch, reduceZoomIdToColumnBounds]
+  )
+  const useZoomItemsMemo = useCallback(
+    () => useZoomItems(useGlobal, zoomItemTapHandler),
+    [useGlobal, zoomItemTapHandler]
+  )
+
   const optionStackPropsz = [
     {
       useTitle: useTuningTitleMemo,
@@ -71,6 +97,11 @@ export const MenuOfTunings = (menuProps: MenuProps): React.ReactElement => {
     {
       useTitle: useValvingTitleMemo,
       useItems: useValvingItemsMemo,
+      twoColumns: false,
+    },
+    {
+      useTitle: useZoomTitleMemo,
+      useItems: useZoomItemsMemo,
       twoColumns: false,
     },
   ]


### PR DESCRIPTION
Reverts js-jslog/harpguru#125

In preparation for adding the remaining functionality for zooming and scrolling the harpface.