### PR TITLE
Upgrade failing dependency

### DIFF
--- a/packages/harpguru-core/CHANGELOG.md
+++ b/packages/harpguru-core/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [Unreleased](https://github.com/js-jslog/harpguru/compare/v15.0.0...master) - yyyy-mm-dd
 
+### Fixed
+
+MINOR: Device can now switch to other apps without crashing HarpGuru
+
 ## [v15.0.0](https://github.com/js-jslog/harpguru/releases/tag/v15.0.0) - 2024-08-16
 
 ### Changed

--- a/packages/harpguru-core/package.json
+++ b/packages/harpguru-core/package.json
@@ -28,7 +28,7 @@
     "react-native-gesture-handler": "~2.16.1",
     "react-native-reanimated": "~3.10.1",
     "reactn": "^2.2.7",
-    "use-dimensions": "^1.0.3"
+    "use-dimensions": "^2.0.0"
   },
   "devDependencies": {
     "@testing-library/react-native": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9409,12 +9409,14 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-use-dimensions@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/use-dimensions/-/use-dimensions-1.0.3.tgz#0b026ea3515626e9d738399069a4dacedd397192"
-  integrity sha512-uR4zIbaAkaqUo+aagxG0dL+BSM/3ybSVqNQs1aA6nAo8ta0wX9KiZlp609gI/QBY9cXQNoflP/Sw5sIYo6iXRA==
+use-dimensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/use-dimensions/-/use-dimensions-2.0.0.tgz#8824b9d550c2dc83e413a3d0805a40422e7ba81f"
+  integrity sha512-m7ICsog9z2aQsM6K8tATNiX/Amg3oKKdpqckFDKI9u0CIb2b/GwTxrFUM+jN8LWljNHxzVLh68nLWYvteHak5Q==
+  dependencies:
+    use-force-update "^1.0.10"
 
-use-force-update@^1.0.5:
+use-force-update@^1.0.10, use-force-update@^1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/use-force-update/-/use-force-update-1.0.11.tgz#9483e9cf3e3cfba0f486cce141b66426bcb27619"
   integrity sha512-h4SICYgTJHon8w9dFIqdqR1Vrzdgl4YaRfRwhmAh01kBGljzTICanyfaFU8C4etuEfRdYpE+04XX2ZrEhOWKXQ==


### PR DESCRIPTION
Narrowed the search down to this dependency, updated it and found it worked. Simple as that.

I'm afraid to say that I actually don't know that this dependency is required anymore. I removed it and things seemed to still work. But unfortunately I'm at a stage with this project at the moment where I don't have the time to reassure myself further than running the test suite. As much as this is a capitulation to the project fully being in life support mode I do not want to take the (apparently unnecessary) risk.

I can point to the original introduction of the original inclusion of the hook and identify that the reason given here would seem to still apply: ebadd6c26dd2dce

Of course there is also risk with introducing a major version change too. Perhaps it's almost equivalent. But I do think it's at least slightly lower. The basic functionality of the hook as I need it (to have the hook triggered when the window size changes) is unlikely to have changed.